### PR TITLE
Cosmos DB: Throw proper error message if entity is not present in the…

### DIFF
--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -161,6 +161,8 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
                 {
                     string modelName = GraphQLNaming.ObjectTypeToEntityName(node);
 
+                    AssertIfEntityIsAvailableInConfig(modelName);
+
                     if (EntityWithJoins.TryGetValue(modelName, out List<EntityDbPolicyCosmosModel>? entityWithJoins))
                     {
                         entityWithJoins.Add(new(Path: CosmosQueryStructure.COSMOSDB_CONTAINER_DEFAULT_ALIAS, EntityName: modelName));
@@ -222,6 +224,9 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
                 }
 
                 string entityType = field.Type.NamedType().Name.Value;
+
+                AssertIfEntityIsAvailableInConfig(entityType);
+
                 // If the entity is already visited, then it is a circular reference
                 if (!trackerForFields.Add(entityType))
                 {
@@ -241,11 +246,12 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
                 }
 
                 EntityDbPolicyCosmosModel currentEntity = new(
-                            Path: currentPath,
-                            EntityName: entityType,
-                            ColumnName: field.Name.Value,
-                            Alias: alias);
+                                Path: currentPath,
+                                EntityName: entityType,
+                                ColumnName: field.Name.Value,
+                                Alias: alias);
 
+                // If entity is defined in the runtime config, only then generate Join for this entity
                 if (EntityWithJoins.ContainsKey(entityType))
                 {
                     EntityWithJoins[entityType].Add(currentEntity);
@@ -255,7 +261,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
                     EntityWithJoins.Add(
                         entityType,
                         new List<EntityDbPolicyCosmosModel>() {
-                            currentEntity
+                        currentEntity
                         });
                 }
 
@@ -279,6 +285,18 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
                     tableCounter: tableCounter,
                     parentEntity: isArrayType ? currentEntity : null,
                     visitedEntities: trackerForFields);
+            }
+        }
+
+        private void AssertIfEntityIsAvailableInConfig(string entityName)
+        {
+            // If the entity is not present in the runtime config, throw an exception as we are expecting all the entities to be present in the runtime config.
+            if (!_runtimeConfig.Entities.ContainsKey(entityName))
+            {
+                throw new DataApiBuilderException(
+                    message: $"The entity '{entityName}' was not found in the runtime config.",
+                    statusCode: System.Net.HttpStatusCode.ServiceUnavailable,
+                    subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
             }
         }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -19,7 +19,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using Azure.DataApiBuilder.Config;
-using Azure.DataApiBuilder.Config.NamingPolicies;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.AuthenticationHelpers;
 using Azure.DataApiBuilder.Core.Authorization;
@@ -432,7 +431,7 @@ type Character {
     moons: [Moon],
 }
 
-type Planet @model(name:""Planet"") {
+type Planet @model(name:""PlanetAlias"") {
     id : ID!,
     name : String,
     character: Character
@@ -453,7 +452,7 @@ type Character {
     moons: Moon,
 }
 
-type Planet @model(name:""Planet"") {
+type Planet @model(name:""PlanetAlias"") {
     id : ID!,
     name : String,
     character: Character
@@ -3068,67 +3067,55 @@ type Moon {
         }
 
         /// <summary>
-        /// When you query, DAB loads schema and check for defined entities in the config file which get load during DAB initialization, and
-        /// it fails during this check if entity is not defined in the config file. In this test case, we are testing the error message is appropriate.
+        /// GraphQL Schema types defined -> Character and Planet
+        /// DAB runtime config entities defined -> Planet(Not defined: Character)
+        /// Mismatch of entities and types between provided GraphQL schema file and DAB config results in actionable error message.
         /// </summary>
+        /// <exception cref="ApplicationException"></exception>
         [TestMethod, TestCategory(TestCategory.COSMOSDBNOSQL)]
-        public async Task TestErrorMessageWithoutKeyFieldsInConfig()
+        public void ValidateGraphQLSchemaEntityPresentInConfig()
         {
-            Dictionary<string, object> dbOptions = new();
-            HyphenatedNamingPolicy namingPolicy = new();
+            string GRAPHQL_SCHEMA = @"
+type Character {
+    id : ID,
+    name : String,
+}
 
-            dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database)), "graphqldb");
-            dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container)), "dummy");
-            dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema)), "custom-schema.gql");
-
-            DataSource dataSource = new(DatabaseType.CosmosDB_NoSQL,
-                GetConnectionStringFromEnvironmentConfig(environment: TestCategory.COSMOSDBNOSQL), Options: dbOptions);
-
-            // Add a dummy entity in config file just to make sure the config file is valid.
-            Entity entity = new(
-                Source: new("EntityName", EntitySourceType.Table, null, null),
-                Rest: new(Enabled: false),
-                GraphQL: new("", ""),
-                Permissions: new[] { GetMinimalPermissionConfig(AuthorizationResolver.ROLE_ANONYMOUS) },
-                Relationships: null,
-                Mappings: null
-            );
-            RuntimeConfig configuration = InitMinimalRuntimeConfig(dataSource, new(), new(), entity, "EntityName");
-
-            const string CUSTOM_CONFIG = "custom-config.json";
-
-            File.WriteAllText(CUSTOM_CONFIG, configuration.ToJson());
-
-            string[] args = new[]
+type Planet @model(name:""PlanetAlias"") {
+    id : ID!,
+    name : String,
+    characters : [Character]
+}";
+            // Read the base config from the file system
+            TestHelper.SetupDatabaseEnvironment(TestCategory.COSMOSDBNOSQL);
+            FileSystemRuntimeConfigLoader baseLoader = TestHelper.GetRuntimeConfigLoader();
+            if (!baseLoader.TryLoadKnownConfig(out RuntimeConfig baseConfig))
             {
-                $"--ConfigFileName={CUSTOM_CONFIG}"
-            };
-
-            using (TestServer server = new(Program.CreateWebHostBuilder(args)))
-            using (HttpClient client = server.CreateClient())
-            {
-                // When you query, DAB loads schema and check for defined entities in the config file and
-                // it fails during that, since entity is not defined in the config file.
-                string query = @"{
-                    Planet {
-                        items{
-                            id
-                        }
-                    }
-                }";
-
-                object payload = new { query };
-
-                HttpRequestMessage graphQLRequest = new(HttpMethod.Post, "/graphql")
-                {
-                    Content = JsonContent.Create(payload)
-                };
-
-                DataApiBuilderException ex = await Assert.ThrowsExceptionAsync<DataApiBuilderException>(async () => await client.SendAsync(graphQLRequest));
-                Assert.AreEqual("The entity 'Planet' was not found in the runtime config.", ex.Message);
-                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
-                Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ConfigValidationError, ex.SubStatusCode);
+                throw new ApplicationException("Failed to load the default CosmosDB_NoSQL config and cannot continue with tests.");
             }
+
+            Dictionary<string, Entity> entities = new(baseConfig.Entities);
+            entities.Remove("Character");
+
+            RuntimeConfig runtimeConfig = new(Schema: baseConfig.Schema,
+                                             DataSource: baseConfig.DataSource,
+                                             Runtime: baseConfig.Runtime,
+                                             Entities: new(entities));
+
+            // Setup a mock file system, and use that one with the loader/provider for the config
+            MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>()
+            {
+                { @"../schema.gql", new MockFileData(GRAPHQL_SCHEMA) },
+                { DEFAULT_CONFIG_FILE_NAME, new MockFileData(runtimeConfig.ToJson()) }
+            });
+            FileSystemRuntimeConfigLoader loader = new(fileSystem);
+            RuntimeConfigProvider provider = new(loader);
+
+            DataApiBuilderException exception =
+                Assert.ThrowsException<DataApiBuilderException>(() => new CosmosSqlMetadataProvider(provider, fileSystem));
+            Assert.AreEqual("The entity 'Character' was not found in the runtime config.", exception.Message);
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, exception.StatusCode);
+            Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ConfigValidationError, exception.SubStatusCode);
         }
 
         /// <summary>

--- a/src/Service.Tests/Multidab-config.CosmosDb_NoSql.json
+++ b/src/Service.Tests/Multidab-config.CosmosDb_NoSql.json
@@ -33,7 +33,7 @@
     }
   },
   "entities": {
-    "Planet": {
+    "PlanetAlias": {
       "source": {
         "object": "graphqldb.planet"
       },
@@ -124,7 +124,7 @@
         }
       ]
     },
-    "StarAlias": {
+    "Star": {
       "source": {
         "object": "graphqldb.star"
       },

--- a/src/Service.Tests/schema.gql
+++ b/src/Service.Tests/schema.gql
@@ -7,7 +7,7 @@ type Character @model(name:"Character") {
     star: Star
 }
 
-type Planet @model(name:"Planet"){
+type Planet @model(name:"PlanetAlias"){
     id : ID,
     name : String,
     character: Character,
@@ -16,7 +16,7 @@ type Planet @model(name:"Planet"){
     stars: [Star]
 }
 
-type Star @model(name:"StarAlias"){
+type Star {
     id : ID,
     name : String
 }


### PR DESCRIPTION
… runtime config (#2272)

## Why make this change?

Customers are getting` System.Collections.Generic.KeyNotFoundException` when there configuration is missing for an entity defined in schema file.

## What is this change?
As part of this PR, throwing proper message saying, entity is not present in runtimeconfig.

Similar changes were made at this PR also
https://github.com/Azure/data-api-builder/pull/2186 ## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

Closes #2266 #887

---------

## Why make this change?

- Reference associated issue using `#` syntax. e.g. Closes #XX
  - Include summary (1-2 sentences) of linked issue to avoid redirecting reviewers to different pages.
  - Include links to any additional discussion threads related to this change.

## What is this change?

- Summary of how your changes work to give reviewers context of your intent.
  - Links to relevant documentation / StackOverflow, if applicable.

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)

- Example REST and/or GraphQL request to demonstrate modifications
- Example of CLI usage to demonstrate modifications
